### PR TITLE
Update README to include Babel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ mochaTest: {
 }
 ```
 
+This is an example for the Babel 6 compiler ([babel must be configured](https://babeljs.io/docs/setup/) separately if you want to use it for something like ES6/ES2015).
+
+```
+npm install babel-register
+```
+
+```javascript
+mochaTest: {
+  test: {
+    options: {
+      reporter: 'spec',
+      require: 'babel-register'
+    },
+    src: ['test/**/*.js']
+  }
+}
+```
+
 In order to make this more user friendly, the `require` option can take either a single file/function or an array of files/functions in case you have other globals you wish to require.
 
 eg.


### PR DESCRIPTION
I use ES2015 in most of my JavaScript projects now and I suspect others are in the same situation. The ES2015 syntax additions may be even more popular than CoffeeScript at the moment. Since there is a CoffeeScript example, I think it would be helpful to include a brief Babel example as well, just to help people get on the right path.

Since Babel 6 does not automatically transpile ES2015, I also added a link to the setup instructions. I'd like to link directly to the Mocha instructions, but that doesn't seem to be possible.
